### PR TITLE
refactor: Switch to actions-based GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,55 +1,37 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Deploy main branch to production
   push:
     branches: ["main"]
-
-  # Deploy PR previews
-  pull_request:
-    branches: ["main"]
-    types: [opened, synchronize, reopened, closed]
-
-  # Allow manual deployment
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
-  group: pages-${{ github.ref }}
+  group: "pages"
   cancel-in-progress: false
 
 jobs:
   deploy:
-    # Skip on PR close events (handled by cleanup job)
-    if: github.event.action != 'closed'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './docs'
 
       - name: Deploy to GitHub Pages
-        uses: rossjrw/pr-preview-action@v1
-        with:
-          source-dir: ./docs
-          preview-branch: gh-pages
-          umbrella-dir: pr-previews
-          action: auto
-
-  cleanup:
-    # Only run when PR is closed
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Remove PR Preview
-        uses: rossjrw/pr-preview-action@v1
-        with:
-          source-dir: ./docs
-          preview-branch: gh-pages
-          umbrella-dir: pr-previews
-          action: remove
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,46 @@
+name: PR Preview Build
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-preview-${{ github.event.pull_request.number }}
+          path: './docs'
+          retention-days: 7
+
+      - name: Comment PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const runId = context.runId;
+            const comment = `## 📦 PR Preview Built
+
+            The site has been built and is available as a downloadable artifact in this workflow run.
+
+            **To preview locally:**
+            1. Download the artifact from the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${runId})
+            2. Extract and open \`index.html\` in your browser
+
+            Or wait for this PR to be merged to see it live on GitHub Pages.`;
+
+            github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });


### PR DESCRIPTION
Simplified deployment by switching from branch-based (gh-pages) to actions-based artifact deployment. This is the recommended modern approach and requires less maintenance.

Main deployment:
- Uses official actions/deploy-pages@v4 with artifact upload
- Deploys from main branch only
- No gh-pages branch management needed

PR previews:
- Builds docs and uploads as downloadable artifact
- Posts comment with preview instructions
- Simpler than managing preview branches

Repository settings needed:
- Go to Settings → Pages
- Set source to "GitHub Actions" (not "Deploy from a branch")

This is much simpler and more reliable than managing a gh-pages branch.